### PR TITLE
fix(posts_controller.rb): remove only published from show action

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.published.friendly.find(params[:id])
+    @post = Post.friendly.find(params[:id])
   end
 
   def rss_feed


### PR DESCRIPTION
On click in the friendly id, there is no published because it is a draft.
The post helper has this link to post which needs the controller to show also drafts.
close #47 
![Screenshot from 2022-01-21 19-28-58](https://user-images.githubusercontent.com/52010485/150608592-58d2eaa1-2bd8-49c8-8192-dd30d22579bf.png)
