### PR TITLE
fix: broken link

### DIFF
--- a/app/views/about/show.html.erb
+++ b/app/views/about/show.html.erb
@@ -13,7 +13,7 @@
     <div class="text-left sm:mx-auto lg:mx-0 sm:container lg:px-0 lg:w-2/3">
       <p class="py-2 lg:mr-16">I'm a software developer mostly working with Ruby on Rails.</p>
 
-      <p class="py-2 lg:mr-16">I'm currently helping companies build their own online training academies, at <a href="https://www.trybugle.com" target="_blank" class="underline">bugle</a>.
+      <p class="py-2 lg:mr-16">I'm currently helping companies build their own online training academies, at bugle (now part of <a href="https://www.hibob.com/log-in/" target="_blank" class="underline">hibob</a>).
 
       <p class="py-2 lg:mr-16">Before making a career switch to programming, I graduated in business management and accepted a few business roles in digital/tech companies.</p>
 


### PR DESCRIPTION
http://www.trybugle.com/ seems to be down, perhaps due to the recent acquisition by hibob. 

This PR updates the copy and link to reflect that.

<img width="520" alt="Screenshot 2022-10-27 at 10 44 23" src="https://user-images.githubusercontent.com/60197762/198252494-2e7fadf1-470c-47eb-aaf9-b5d080b5c2e9.png">
